### PR TITLE
my lists page formatting

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -4,11 +4,23 @@
     ViewData["Title"] = "Home page";
 }
 
+@using Microsoft.AspNetCore.Identity
+
+@inject SignInManager<IdentityUser> SignInManager
+@inject UserManager<IdentityUser> UserManager
+
+
+
 <br>
 
 <div id="home_head">
     <h1>ISeeGreen Plant Identification</h1>
 </div>
+
+@if (SignInManager.IsSignedIn(User))
+{
+        <p>Hello @UserManager.GetUserName(User)!</p>
+}
 
 <br>
 

--- a/Pages/Lists/Create.cshtml
+++ b/Pages/Lists/Create.cshtml
@@ -5,6 +5,11 @@
     ViewData["Title"] = "Create";
 }
 
+@using Microsoft.AspNetCore.Identity
+
+@inject SignInManager<IdentityUser> SignInManager
+@inject UserManager<IdentityUser> UserManager
+
 <h1>Create</h1>
 
 <h4>Lists</h4>
@@ -20,7 +25,7 @@
             </div>
             <div class="form-group">
                 <label asp-for="Lists.OwnerID" class="control-label"></label>
-                <select asp-for="Lists.OwnerID" class ="form-control" asp-items="ViewBag.OwnerID"></select>
+                <input asp-for="Lists.OwnerID" value="@UserManager.GetUserId(User)" readonly />
             </div>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />

--- a/Pages/Lists/Index.cshtml
+++ b/Pages/Lists/Index.cshtml
@@ -5,10 +5,20 @@
     ViewData["Title"] = "Index";
 }
 
+@using Microsoft.AspNetCore.Identity
+
+@inject SignInManager<IdentityUser> SignInManager
+@inject UserManager<IdentityUser> UserManager
+
 <br> 
 <div id="header_box">
 <h1 id="search_heading">My Lists</h1>
 </div>
+
+@if (SignInManager.IsSignedIn(User))
+{
+        <p>Hello @UserManager.GetUserName(User)!</p>
+
 
 <p>
     <a asp-page="Create">Create New</a>
@@ -16,6 +26,7 @@
 
 <div class="row">
     @foreach (var item in Model.Lists) {
+      if (item.OwnerID == UserManager.GetUserId(User)) {
         <div class="column">
             <div class="card">
                 <h2><b>@Html.DisplayFor(modelItem => item.Name)</b></h2>
@@ -28,8 +39,11 @@
                 
             </div>
         </div>
+      }
+        
     }
 </div>
+}
 
 <style>
     * {

--- a/Pages/Lists/Index.cshtml
+++ b/Pages/Lists/Index.cshtml
@@ -5,39 +5,92 @@
     ViewData["Title"] = "Index";
 }
 
-<h1>My Lists</h1>
+<br> 
+<div id="header_box">
+<h1 id="search_heading">My Lists</h1>
+</div>
 
 <p>
     <a asp-page="Create">Create New</a>
 </p>
-<table class="table">
-    <thead>
-        <tr>
-            <th>
-                @Html.DisplayNameFor(model => model.Lists[0].Name)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Lists[0].Owner)
-            </th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-@foreach (var item in Model.Lists) {
-        <tr>
-            <td>
-                @Html.DisplayFor(modelItem => item.Name)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Owner.Id)
-            </td>
-            <td>
-                <a asp-page="./Edit" asp-route-id="@item.Id">Edit</a> |
-                <a asp-page="./Details" asp-route-id="@item.Id">Details</a> |
-                <a asp-page="./Delete" asp-route-id="@item.Id">Delete</a>
-                <a asp-page="/ListItems/Index" asp-route-itemid="@item.Id">Items</a>
-            </td>
-        </tr>
+
+<div class="row">
+    @foreach (var item in Model.Lists) {
+        <div class="column">
+            <div class="card">
+                <h2><b>@Html.DisplayFor(modelItem => item.Name)</b></h2>
+                <div class="cardtag">
+                    <a asp-page="/ListItems/Index" asp-route-itemid="@item.Id">Items</a>
+                    <a asp-page="./Edit" asp-route-id="@item.Id">Edit</a> |
+                    <a asp-page="./Details" asp-route-id="@item.Id">Details</a> |
+                    <a asp-page="./Delete" asp-route-id="@item.Id">Delete</a>
+                </div>
+                
+            </div>
+        </div>
+    }
+</div>
+
+<style>
+    * {
+  box-sizing: border-box;
 }
-    </tbody>
-</table>
+
+body {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+h2 {
+    font-size: 18px;
+}
+
+p {
+    font-size: 14px;
+}
+
+/* Float four columns side by side */
+.column {
+  float: left;
+  width: 25%;
+  padding: 0 10px;
+  margin-bottom: 20px;
+}
+
+/* Remove extra left and right margins, due to padding in columns */
+.row {
+    margin: 0 -5px;
+    margin-bottom: 10px;
+}
+
+/* Clear floats after the columns */
+.row:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+/* Style the counter cards */
+.card {
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2); /* this adds the "card" effect */
+  padding: 24px;
+  text-align: center;
+  background-color: #f1f1f1;
+  outline: darkgreen 1px;
+  height: 200px;
+}
+
+.card:hover {
+  box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
+  background-color: #bdd0ac;
+}
+
+/* Responsive columns - one column layout (vertical) on small screens */
+@@media screen and (max-width: 600px) {
+  .column {
+    width: 100%;
+    display: block;
+    margin-bottom: 20px;
+  }
+}
+</style>
+

--- a/Pages/Lists/Index.cshtml
+++ b/Pages/Lists/Index.cshtml
@@ -5,7 +5,7 @@
     ViewData["Title"] = "Index";
 }
 
-<h1>Index</h1>
+<h1>My Lists</h1>
 
 <p>
     <a asp-page="Create">Create New</a>
@@ -35,6 +35,7 @@
                 <a asp-page="./Edit" asp-route-id="@item.Id">Edit</a> |
                 <a asp-page="./Details" asp-route-id="@item.Id">Details</a> |
                 <a asp-page="./Delete" asp-route-id="@item.Id">Delete</a>
+                <a asp-page="/ListItems/Index" asp-route-itemid="@item.Id">Items</a>
             </td>
         </tr>
 }

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -28,7 +28,7 @@
                             <a class="nav-link text-light" asp-area="" asp-page="/Search/Index">Search</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-light" asp-area="" asp-page="/My_Lists">My Lists</a>
+                            <a class="nav-link text-light" asp-area="" asp-page="/Lists/Index">My Lists</a>
                         </li>
                     </ul>
                 </div>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -18,22 +18,24 @@
                 </button>
                 <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
                     <ul class="navbar-nav bg-#486034 flex-grow-1 justify-content-center">
-                        <li class="nav-item" id="homenav">
+                        <li class="nav-item" id="homenav1">
                             <a class="nav-link text-light" asp-area="" asp-page="/Index">Home</a>
                         </li>
-                        <li class="nav-item">
+                        <li class="nav-item" id="homenav1">
                             <a class="nav-link text-light" asp-area="" asp-page="/About">About</a>
                         </li>
-                        <li class="nav-item">
+                        <li class="nav-item" id="homenav1">
                             <a class="nav-link text-light" asp-area="" asp-page="/Search/Index">Search</a>
                         </li>
-                        <li class="nav-item">
+                        <li class="nav-item" id="homenav1">
                             <a class="nav-link text-light" asp-area="" asp-page="/Lists/Index">My Lists</a>
                         </li>
+                        @* <button type=button id=home_loginbutton>Log In</button> *@
+                    <partial name="_LoginPartial" />
                     </ul>
+                    
                 </div>
-                @* <button type=button id=home_loginbutton>Log In</button> *@
-                <partial name="_LoginPartial" />
+                
             </div>
         </nav>
     </header>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,9 @@
-﻿<!DOCTYPE html>
+﻿@using Microsoft.AspNetCore.Identity
+
+@inject SignInManager<IdentityUser> SignInManager
+@inject UserManager<IdentityUser> UserManager
+
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
@@ -28,7 +33,9 @@
                             <a class="nav-link text-light" asp-area="" asp-page="/Search/Index">Search</a>
                         </li>
                         <li class="nav-item" id="homenav1">
-                            <a class="nav-link text-light" asp-area="" asp-page="/Lists/Index">My Lists</a>
+                            @if (SignInManager.IsSignedIn(User))
+                                    { <a class="nav-link text-light" asp-area="" asp-page="/Lists/Index">My Lists</a>
+                                        }                
                         </li>
                         @* <button type=button id=home_loginbutton>Log In</button> *@
                     <partial name="_LoginPartial" />

--- a/Pages/Shared/_LoginPartial.cshtml
+++ b/Pages/Shared/_LoginPartial.cshtml
@@ -3,25 +3,30 @@
 @inject SignInManager<IdentityUser> SignInManager
 @inject UserManager<IdentityUser> UserManager
 
-<ul class="navbar-nav">
+<ul class="navbar-nav" id="nav1">
 @if (SignInManager.IsSignedIn(User))
 {
     <li class="nav-item">
-        <a id="manage" class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Manage/Index" title="Manage">Hello @UserManager.GetUserName(User)!</a>
-    </li>
-    <li class="nav-item">
         <form id="logoutForm" class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Page("/Index", new { area = "" })">
-            <button id="logout" type="submit" class="nav-link btn btn-link text-dark border-0">Logout</button>
+            <button id="logout" type="submit" class="nav-link btn btn-link text-light border-0">Logout</button>
         </form>
     </li>
 }
 else
 {
     <li class="nav-item">
-        <a class="nav-link text-dark" id="register" asp-area="Identity" asp-page="/Account/Register">Register</a>
+        <a class="nav-link text-light" id="register" asp-area="Identity" asp-page="/Account/Register">Register</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link text-dark" id="login" asp-area="Identity" asp-page="/Account/Login">Login</a>
+        <a class="nav-link text-light" id="login" asp-area="Identity" asp-page="/Account/Login">Login</a>
     </li>
 }
 </ul>
+
+<style>
+    #nav1 {
+        position: absolute;
+        right: 10px;
+    }
+    /* fix resizing issue */
+</style>


### PR DESCRIPTION
- added ability to access my list page by nav bar link
- reformatted lists to display as cards, instead of table entries
- moved "hello ___" out of navbar to preserve aspect ratio; will incorporate into page styling instead 
-  modified my lists to only display lists associated with the currently logged-in user

note: we will need to modify the "Create new" for my lists. the dropdown does not automatically select the owner id associated with the current user, so a user could make a list for another account, but then not be able to see it. 